### PR TITLE
Fix source-url in META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,5 +3,5 @@
     "version"     : "*",
     "description" : "A continuous test runner for Perl 6",
     "depends"     : [ ],
-    "source-url"  : "git://github.com/gam/test-junkie.git"
+    "source-url"  : "git://github.com/gam/Test-Junkie.git"
 }


### PR DESCRIPTION
It now cannot be installed using a module manager, and smoketested for the same reason.
