### PR TITLE
Bring up to current Rakudo implementation

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,5 +3,5 @@
     "version"     : "*",
     "description" : "A continuous test runner for Perl 6",
     "depends"     : [ ],
-    "source-url"  : "git://github.com/gam/Test-Junkie.git"
+    "source-url"  : "git://github.com/colomon/Test-Junkie.git"
 }

--- a/lib/Test/Junkie.pm
+++ b/lib/Test/Junkie.pm
@@ -35,7 +35,7 @@ class Tracker {
     sub find_files(*@dirs) {
         for @dirs -> $directory {
             for dir($directory) -> $file {
-                given "$directory/$file".IO { 
+                given $file.IO { 
                     when .f { take $_ }
                     when .d { find_files .path }
                 }


### PR DESCRIPTION
p6 dir sub now returns IO::Path, which includes the path in its stringification.
